### PR TITLE
Toykeeper conversion + buffered output handling

### DIFF
--- a/energymech-log-converter.py
+++ b/energymech-log-converter.py
@@ -23,6 +23,7 @@ Options
 --format Convert log as <FORMAT>
 
 """
+import sys
 
 import argparse
 
@@ -32,12 +33,75 @@ import sqlite3
 
 import importlib
 
+
+
+class BufferedOutputHandler():
+  """ Template output buffer.
+    Implementations should all handle 'day' updates. """
+
+  def __init__(self,filepath):
+    raise NotImplementedError("Don't intialise the BufferedOutputHandler directly, but one of its implementations.") 
+
+  def begin(self):
+    pass
+    
+  def write_day(self):
+    pass
+
+  def close(self):
+    pass
+
+
+class BufferedSqliteOutputHandler(BufferedOutputHandler):
+  """ To be implemented.. """
+  pass
+
+
+class BufferedJSONOutputHandler(BufferedOutputHandler):
+  """ Implements buffered output to JSON of logs being read. """
+
+  def __init__(self, filepath):
+    """ Configure the class with output format, path, etc.
+        Should probably refactor so that format is handled by subclasses
+        implementing this interface rather than internal logic. """
+    self.outfile = open(filepath,'w')
+    self.prevday = False
+    
+  def begin(self):
+    """ Handle any initial writes. """
+    self.outfile.write("{\n")
+  
+  def write_day(self,day):
+    """ Writes a day's entry.
+
+    Arguments:
+      day: a dict (usually of one entry) which has a 'datestring':array_of_lines format. """
+    #strip the object braces.
+    outstr = json.dumps(day,indent=2)[2:-2]
+    if self.prevday:
+      self.outfile.write(',\n')
+    else:
+      self.prevday = True
+    self.outfile.write(outstr)
+
+  def close(self):
+    """ Close the log. """
+    self.outfile.write("\n}\n")
+    self.outfile.close()
+
+
 class conversion_wrapper():
   """Wraps the various converters and imports them all into one unified interface."""
+
+
   def main():
     """Implement command line interface and call subroutines to handle conversions."""
+
+    supported_formats = {'json':BufferedJSONOutputHandler,
+                         'sqlite': BufferedSqliteOutputHandler}
+
     parser = argparse.ArgumentParser()
-    parser.add_argument("Directory", help="The directory in which the log files reside.")
+    parser.add_argument("logs", help="The logfile or the directory in which the log files reside.")
     parser.add_argument("--output", "-o", help="Filepath to store output at, default is standard output.")
     formats_help = """\n\nValid formats are:\n\n\tjson\n\tsqlite"""
     parser.add_argument("--oformat", help="The format to output." + formats_help)
@@ -46,25 +110,25 @@ class conversion_wrapper():
 
     arguments = parser.parse_args()
 
-    if arguments.oformat:
-      try:
-        converter = importlib.import_module("converters." + arguments.format)
-      except ImportError:
-        raise ValueError("Given format " + arguments.format.upper() + " has no valid converter.")
-      if arguments.oformat == "sqlite":
-        if arguments.output:
-          # To be implemented later
-          raise ValueError("SQL formatting not implemented at this time. Check back for further updates to this software.")
-        else:
-          raise ValueError("SQL formatting not implemented at this time. Check back for further updates to this software.")
-      else:
-        if arguments.output:
-          jsondump = open(arguments.output, 'w')
+    try:
+      converter = importlib.import_module("converters." + arguments.format)
+    except ImportError:
+      raise ValueError("Given format " + arguments.format.upper() + " has no valid converter.")
 
-          json.dump(converter.convert(arguments.Directory, "json"), jsondump, indent=2)
-        else:
-          print(json.dumps(converter.convert(arguments.Directory, "json"), indent=2))
-    else:
+    if not arguments.oformat:
       raise ValueError("Did not specify an output format.")
+    elif arguments.oformat not in supported_formats:
+      raise ValueError("Do not recognise output format '{}'".format(arguments.ofile))
+    elif arguments.oformat == 'sqlite':
+      raise ValueError("SQL formatting not implemented at this time. Check back for further updates to this software.")
+
+    ofile = arguments.output if arguments.output else sys.stdout
+    output_handler = BufferedJSONOutputHandler(ofile)
+
+    try:
+      converter.convert(arguments.logs, output_handler)
+    except KeyboardInterrupt as ki:
+      #Should mean we mostly get valid data out of truncated converts.
+      output_handler.close()
   
 conversion_wrapper.main()


### PR DESCRIPTION
## Output Format

The converters have both been altered so that instead of a log
format they are passed an output_handler object which implements
an output format. This operates on a day-by-day buffer, with
the input converter responsible for building up a day's entry and
passing this to the output handler in the expected pythonic format.

The only implemented output handler at the moment is the JSON
output handler.

As per namespace's request, the Toykeeper log parser reads
line-by-line from files rather than loading them into memory.
The changes to the energymech reader have been minimal, but
are untested due to the lack of test data for that format.

To retain backwards compatibility, leaving the output_handler
as None will cause the converters to merely stash their input
in a python object structure and return it on completion.
This will of course mean greater memory usage than using the
buffered output handler system.

The code for the output handlers is currently in the main
frontend file. It may be worth working out a different location
for this.
## Interface

I have tweaked the code in the frontend to some degree. The
changes here are not highly important.
