### PR TITLE
Datestamp fix; STDOUT handling, outline of Sqlite.

### DIFF
--- a/converters/toykeeper.py
+++ b/converters/toykeeper.py
@@ -46,16 +46,16 @@ class ToyKeeperConverter():
 
     day = []
     logfile = open(filepath, 'r', encoding='latin-1')
-    current_date = logfile.readline().split(" ")[0]
+    current_date = int(time.mktime(time.strptime(logfile.readline().split(" ")[0], "%Y-%m-%d")))
     line_id = 0
 
 
     for line in logfile:
       line_elements = process_line(line_id, line, utc_offset)
       day.append(line_elements["converted_line"])
-      if line_elements["date"] > current_date:
+      if int(line_elements["offset_datestamp"]) > current_date:
         shift_day(day,current_date)
-        current_date = line_elements["date"]
+        current_date = int(line_elements["offset_datestamp"])
         day = []
 
       line_id += 1  


### PR DESCRIPTION
The datestamps from Toykeeper are now in the integer format which
corresponds with what the energymech converter users.

The JSON handler now correctly handles stdout, but the way this is
handled should be altered anyway as Sqlite can't write to stdout
sensibly (I think, at any rate).

The Sqlite stuff is very partial and not even remotely tested,
only an outline of what's going to be done. It will not work, and
bits which exist will be wrong.
